### PR TITLE
Ignore Maven build directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Maven
+target/


### PR DESCRIPTION
In order to ignore all building directories created by Maven, add a `.gitignore` file in the root directory.
